### PR TITLE
fix: change Search output to array for program usage

### DIFF
--- a/upstream/installer.go
+++ b/upstream/installer.go
@@ -11,5 +11,5 @@ type Installer interface {
 	Install(pkg Package, outputDir string) error
 	// Search checks remote repository for the specified package availability.
 	// Returns the search results text and any encountered errors.
-	Search(pkg Package) (string, error)
+	Search(pkg Package) ([]string, error)
 }

--- a/upstream/installer/conan/conaninst.go
+++ b/upstream/installer/conan/conaninst.go
@@ -110,7 +110,7 @@ func (c *conanInstaller) Search(pkg upstream.Package) ([]string, error) {
 	regex := regexp.MustCompile(fmt.Sprintf("%s/.*", pkg.Name))
 
 	for _, field := range strings.Fields(string(out)) {
-		if regex.Match([]byte(field)) {
+		if regex.MatchString(field) {
 			ret = append(ret, field)
 		}
 	}

--- a/upstream/installer/conan/conaninst.go
+++ b/upstream/installer/conan/conaninst.go
@@ -3,7 +3,6 @@ package conan
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/goplus/llpkgstore/internal/cmdbuilder"
@@ -107,10 +106,9 @@ func (c *conanInstaller) Search(pkg upstream.Package) ([]string, error) {
 
 	var ret []string
 
-	regex := regexp.MustCompile(fmt.Sprintf("%s/.*", pkg.Name))
-
 	for _, field := range strings.Fields(string(out)) {
-		if regex.MatchString(field) {
+		prefix, _, found := strings.Cut(field, "/")
+		if found && prefix == pkg.Name {
 			ret = append(ret, field)
 		}
 	}

--- a/upstream/installer/conan/conaninst_test.go
+++ b/upstream/installer/conan/conaninst_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/goplus/llpkgstore/upstream"
@@ -37,6 +38,23 @@ func TestConanInstaller(t *testing.T) {
 
 	if err := verify(pkg, tempDir); err != nil {
 		t.Errorf("Verify failed: %s", err)
+	}
+}
+
+func TestConanSearch(t *testing.T) {
+	c := &conanInstaller{
+		config: map[string]string{
+			"options": `cjson/*:utils=True`,
+		},
+	}
+
+	pkg := upstream.Package{
+		Name:    "cjson",
+		Version: "1.7.18",
+	}
+	ver, _ := c.Search(pkg)
+	if !slices.Contains(ver, "cjson/1.7.18") {
+		t.Errorf("unexpected search result: %s", ver)
 	}
 }
 

--- a/upstream/installer/conan/conaninst_test.go
+++ b/upstream/installer/conan/conaninst_test.go
@@ -56,6 +56,17 @@ func TestConanSearch(t *testing.T) {
 	if !slices.Contains(ver, "cjson/1.7.18") {
 		t.Errorf("unexpected search result: %s", ver)
 	}
+
+	pkg = upstream.Package{
+		Name:    "cjson2",
+		Version: "1.7.18",
+	}
+
+	_, err := c.Search(pkg)
+	if err == nil {
+		t.Errorf("unexpected behavior: %s", err)
+	}
+
 }
 
 func verify(pkg upstream.Package, installDir string) error {

--- a/upstream/installer/conan/conaninst_test.go
+++ b/upstream/installer/conan/conaninst_test.go
@@ -57,6 +57,8 @@ func TestConanSearch(t *testing.T) {
 		t.Errorf("unexpected search result: %s", ver)
 	}
 
+	t.Log(ver)
+
 	pkg = upstream.Package{
 		Name:    "cjson2",
 		Version: "1.7.18",


### PR DESCRIPTION
Conan `Search` output the list of versions for the package.

However, in the previous version of this implement, the conan `Search` doesn't process the result of the output, which cause caller cannot use it directly and is very meaningless.

Without processing(raw string): 
```
conancenter
  cjson
    cjson/1.7.12
    cjson/1.7.13
    cjson/1.7.14
    cjson/1.7.15
    cjson/1.7.16
    cjson/1.7.17
    cjson/1.7.18
```

With processing(string slice):
```
[cjson/1.7.12 cjson/1.7.13 cjson/1.7.14 cjson/1.7.15 cjson/1.7.16 cjson/1.7.17 cjson/1.7.18]
```

