### PR TITLE
feat: sync installer and generator output to stdout

### DIFF
--- a/internal/actions/generator/llcppg/llcppg.go
+++ b/internal/actions/generator/llcppg/llcppg.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goplus/llpkgstore/internal/actions/file"
 	"github.com/goplus/llpkgstore/internal/actions/generator"
 	"github.com/goplus/llpkgstore/internal/actions/hashutils"
+	"github.com/goplus/llpkgstore/internal/actions/utils"
 )
 
 var (
@@ -129,8 +130,8 @@ func (l *llcppgGenerator) Generate(toDir string) error {
 	cmd.Dir = path
 	// llcppg may exit with an error, which may be caused by Stderr.
 	// To avoid that case, we have to check its exit code.
-	if output, err := cmd.CombinedOutput(); isExitedUnexpectedly(err) {
-		return errors.Join(ErrLlcppgGenerate, errors.New(string(output)))
+	if err := utils.OutputToStdout(cmd); isExitedUnexpectedly(err) {
+		return ErrLlcppgGenerate
 	}
 	// check output again
 	generatedPath := filepath.Join(path, l.packageName)

--- a/internal/actions/utils/utils.go
+++ b/internal/actions/utils/utils.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+)
+
+func OutputToStdout(cmd *exec.Cmd) error {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/upstream/installer/conan/conaninst.go
+++ b/upstream/installer/conan/conaninst.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/goplus/llpkgstore/internal/cmdbuilder"
 	"github.com/goplus/llpkgstore/upstream"
+
+	"github.com/goplus/llpkgstore/internal/actions/utils"
 )
 
 var (
@@ -99,9 +101,8 @@ func (c *conanInstaller) Install(pkg upstream.Package, outputDir string) (string
 
 	buildCmd := builder.Cmd()
 
-	out, err := buildCmd.CombinedOutput()
+	err := utils.OutputToStdout(buildCmd)
 	if err != nil {
-		fmt.Println(string(out))
 		return "", err
 	}
 


### PR DESCRIPTION
In previous version, the result of conan will output to `bytes.Buffer`.

However, when users is generating or installing a large C library, they can't see the output and don't know the progress of installation.

To solve that problem, the result of installer and generator will sync to `stdout` by default.


```
=== RUN   TestConanInstaller
WARN: legacy: Unscoped option definition is ambiguous.
Use '&:utils=True' to refer to the current package.
Use '*:utils=True' or other pattern if the intent was to apply to dependencies
======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=12
os=Linux
[options]
utils=True
*:shared=True

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=12
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    cjson/1.7.18#eeeb2399139bf6e47c45b967280750c3 - Cache

======== Computing necessary packages ========
Requirements
    cjson/1.7.18#eeeb2399139bf6e47c45b967280750c3:1104edccd734dcb4de70a9a4b1935b3ce83484bf#891ae7786f92406063e1242e03a54bb8 - Cache

======== Installing packages ========
cjson/1.7.18: Already installed! (1 of 1)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: cjson/1.7.18
WARN: deprecated:     'cpp_info.build_modules' used in: cjson/1.7.18

======== Finalizing install (deploy, generators) ========
cli: Writing generators to /tmp/llpkg-tool481087499
cli: Generator 'PkgConfigDeps' calling 'generate()'
cli: Generating aggregated env files
cli: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
Install finished successfully
    conaninst_test.go:41: /home/vscode/.conan2/p/b/cjson7fb112e50ddea/p
--- PASS: TestConanInstaller (0.20s)
```