### PR TITLE
feat: sync llcppg output to stdout

### DIFF
--- a/internal/actions/generator/llcppg/llcppg.go
+++ b/internal/actions/generator/llcppg/llcppg.go
@@ -127,10 +127,12 @@ func (l *llcppgGenerator) Generate(toDir string) error {
 	}
 	cmd := exec.Command("llcppg", llcppgConfigFile)
 	cmd.Dir = path
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	// llcppg may exit with an error, which may be caused by Stderr.
 	// To avoid that case, we have to check its exit code.
-	if output, err := cmd.CombinedOutput(); isExitedUnexpectedly(err) {
-		return errors.Join(ErrLlcppgGenerate, errors.New(string(output)))
+	if err := cmd.Run(); isExitedUnexpectedly(err) {
+		return errors.Join(ErrLlcppgGenerate, err)
 	}
 	// check output again
 	generatedPath := filepath.Join(path, l.packageName)


### PR DESCRIPTION
According to the suggestion in #21 from @luoliwoshang, separate this change.

In previous version, the result of llcppg will output to bytes.Buffer.

However, when users is generating or installing a large C library, they can't see the output and don't know the progress of installation.

To solve that problem, the result of installer and generator will sync to stdout by default.