### PR TITLE
fix: llcppg still locks Go version after process was terminated unexpectedly

### DIFF
--- a/internal/actions/generator/llcppg/llcppg.go
+++ b/internal/actions/generator/llcppg/llcppg.go
@@ -124,6 +124,8 @@ func (l *llcppgGenerator) Generate(toDir string) error {
 	cmd.Dir = path
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	lockGoVersion(cmd)
+
 	// llcppg may exit with an error, which may be caused by Stderr.
 	// To avoid that case, we have to check its exit code.
 	if err := cmd.Run(); isExitedUnexpectedly(err) {

--- a/internal/actions/generator/llcppg/llcppg.go
+++ b/internal/actions/generator/llcppg/llcppg.go
@@ -127,10 +127,12 @@ func (l *llcppgGenerator) Generate(toDir string) error {
 	}
 	cmd := exec.Command("llcppg", llcppgConfigFile)
 	cmd.Dir = path
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	// llcppg may exit with an error, which may be caused by Stderr.
 	// To avoid that case, we have to check its exit code.
-	if output, err := cmd.CombinedOutput(); isExitedUnexpectedly(err) {
-		return errors.Join(ErrLlcppgGenerate, errors.New(string(output)))
+	if err := cmd.Run(); isExitedUnexpectedly(err) {
+		return errors.Join(ErrLlcppgGenerate, err)
 	}
 	// check output again
 	generatedPath := filepath.Join(path, l.packageName)

--- a/internal/actions/generator/llcppg/llcppg_test.go
+++ b/internal/actions/generator/llcppg/llcppg_test.go
@@ -19,7 +19,7 @@ const (
   "upstream": {
     "package": {
       "name": "cjson",
-      "version": "1.7.18"
+      "version": "1.7.17"
     }
   }
 }`

--- a/internal/actions/generator/llcppg/llcppg_test.go
+++ b/internal/actions/generator/llcppg/llcppg_test.go
@@ -40,7 +40,7 @@ func checkGoMod(t *testing.T, file string) {
 	b, _ := os.ReadFile(file)
 	f, _ := modfile.Parse(file, b, nil)
 	if f.Go.Version != "1.20" {
-		t.Error("unexpected version")
+		t.Errorf("unexpected version: got: %s", f.Go.Version)
 	}
 }
 

--- a/internal/actions/generator/llcppg/llcppg_test.go
+++ b/internal/actions/generator/llcppg/llcppg_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/goplus/llpkgstore/config"
 	"github.com/goplus/llpkgstore/internal/actions/hashutils"
+	"golang.org/x/mod/modfile"
 )
 
 const (
@@ -34,6 +35,14 @@ const (
     "cplusplus": false
 }`
 )
+
+func checkGoMod(t *testing.T, file string) {
+	b, _ := os.ReadFile(file)
+	f, _ := modfile.Parse(file, b, nil)
+	if f.Go.Version != "1.20" {
+		t.Error("unexpected version")
+	}
+}
 
 func TestHash(t *testing.T) {
 	canHashFn := func(fileName string) bool {
@@ -123,5 +132,9 @@ func TestLlcppg(t *testing.T) {
 		t.Error("unexpected check")
 		return
 	}
+	// check go.mod
+	checkGoMod(t, filepath.Join(path, ".generate", "go.mod"))
+	checkGoMod(t, filepath.Join(path, "go.mod"))
+
 	//generator.Check()
 }


### PR DESCRIPTION
Fixes #18 