### PR TITLE
fix: remove unused file and abs path

### DIFF
--- a/internal/actions/api.go
+++ b/internal/actions/api.go
@@ -544,10 +544,13 @@ func (d *DefaultClient) Release() {
 	}
 	// generate pc template to lib/pkgconfig
 	for _, matchPC := range matches {
-		pc.GenerateTemplateFromPC(matchPC, pkgConfigDir)
+		err := pc.GenerateTemplateFromPC(matchPC, pkgConfigDir)
+		must(err)
 		// okay, safe to remove old pc
 		os.Remove(matchPC)
 	}
+
+	file.RemovePattern(filepath.Join(tempDir, "*.sh"))
 
 	zipFilePath, _ := filepath.Abs(binaryZip(uc.Pkg.Name))
 

--- a/internal/actions/pc/tmpl.go
+++ b/internal/actions/pc/tmpl.go
@@ -15,7 +15,7 @@ func GenerateTemplateFromPC(inputName, outputDir string) error {
 	if err != nil {
 		return err
 	}
-	outputName := filepath.Join(outputDir, inputName+PCTemplateSuffix)
+	outputName := filepath.Join(outputDir, filepath.Base(inputName)+PCTemplateSuffix)
 	pcContent = PrefixMatch.ReplaceAll(pcContent, []byte(`prefix={{.Prefix}}`))
 
 	return os.WriteFile(outputName, pcContent, 0644)

--- a/internal/actions/pc/tmpl_test.go
+++ b/internal/actions/pc/tmpl_test.go
@@ -46,3 +46,21 @@ func TestPCTemplate(t *testing.T) {
 		t.Errorf("unexpected content: got: %s", string(b))
 	}
 }
+
+func TestABSPathPCTemplate(t *testing.T) {
+	pcPath, _ := filepath.Abs("test.pc")
+	os.WriteFile(pcPath, []byte(testPCFile), 0644)
+	os.Mkdir(".generated", 0777)
+	GenerateTemplateFromPC(pcPath, ".generated")
+	defer os.Remove("test.pc")
+	defer os.RemoveAll(".generated")
+	b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if string(b) != expectedContent {
+		t.Errorf("unexpected content: got: %s", string(b))
+	}
+}

--- a/internal/actions/pc/tmpl_test.go
+++ b/internal/actions/pc/tmpl_test.go
@@ -52,7 +52,7 @@ func TestABSPathPCTemplate(t *testing.T) {
 	os.WriteFile(pcPath, []byte(testPCFile), 0644)
 	os.Mkdir(".generated", 0777)
 	GenerateTemplateFromPC(pcPath, ".generated")
-	defer os.Remove("test.pc")
+	defer os.Remove(pcPath)
 	defer os.RemoveAll(".generated")
 	b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
 	if err != nil {


### PR DESCRIPTION
In some cases, matchPC may be a abs path, in that case, `filepath.Join` will get the wrong path.