### PR TITLE
refactor: generate clib's pc only

### DIFF
--- a/internal/actions/pc/tmpl.go
+++ b/internal/actions/pc/tmpl.go
@@ -8,7 +8,11 @@ import (
 
 const PCTemplateSuffix = ".tmpl"
 
-var PrefixMatch = regexp.MustCompile(`^prefix=(.*)`)
+var (
+	// By the way, trim the new line
+	requireMatch = regexp.MustCompile(`\nRequires:\s.*`)
+	PrefixMatch  = regexp.MustCompile(`^prefix=(.*)`)
+)
 
 func GenerateTemplateFromPC(inputName, outputDir string) error {
 	pcContent, err := os.ReadFile(inputName)
@@ -17,6 +21,7 @@ func GenerateTemplateFromPC(inputName, outputDir string) error {
 	}
 	outputName := filepath.Join(outputDir, filepath.Base(inputName)+PCTemplateSuffix)
 	pcContent = PrefixMatch.ReplaceAll(pcContent, []byte(`prefix={{.Prefix}}`))
+	pcContent = requireMatch.ReplaceAll(pcContent, []byte(""))
 
 	return os.WriteFile(outputName, pcContent, 0644)
 }

--- a/internal/actions/pc/tmpl_test.go
+++ b/internal/actions/pc/tmpl_test.go
@@ -20,6 +20,18 @@ Libs: -L"${libdir}" -lxml2 -lm -lpthread -ldl
 Cflags: -I"${includedir}" -I"${includedir1}"
 Requires: zlib`
 
+	testPCFile2 = `prefix=/home/vscode/.conan2/p/b/zlibbe9abfe31bec0/p
+libdir=${prefix}/lib
+includedir=${prefix}/include
+includedir1=${prefix}/include/libxml2
+bindir=${prefix}/bin
+
+Name: libxml-2.0
+Description: Conan package: libxml-2.0
+Version: 2.11.6
+Libs: -L"${libdir}" -lxml2 -lm -lpthread -ldl
+Cflags: -I"${includedir}" -I"${includedir1}"`
+
 	expectedContent = `prefix={{.Prefix}}
 libdir=${prefix}/lib
 includedir=${prefix}/include
@@ -35,6 +47,23 @@ Cflags: -I"${includedir}" -I"${includedir1}"`
 
 func TestPCTemplate(t *testing.T) {
 	os.WriteFile("test.pc", []byte(testPCFile), 0644)
+	os.Mkdir(".generated", 0777)
+	GenerateTemplateFromPC("test.pc", ".generated")
+	defer os.Remove("test.pc")
+	defer os.RemoveAll(".generated")
+	b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if string(b) != expectedContent {
+		t.Errorf("unexpected content: got: %s", string(b))
+	}
+}
+
+func TestPCTemplateNoRequires(t *testing.T) {
+	os.WriteFile("test.pc", []byte(testPCFile2), 0644)
 	os.Mkdir(".generated", 0777)
 	GenerateTemplateFromPC("test.pc", ".generated")
 	defer os.Remove("test.pc")

--- a/internal/actions/pc/tmpl_test.go
+++ b/internal/actions/pc/tmpl_test.go
@@ -10,24 +10,27 @@ const (
 	testPCFile = `prefix=/home/vscode/.conan2/p/b/zlibbe9abfe31bec0/p
 libdir=${prefix}/lib
 includedir=${prefix}/include
+includedir1=${prefix}/include/libxml2
 bindir=${prefix}/bin
 
-Name: zlib
-Description: Conan package: zlib
-Version: 1.3.1
-Libs: -L"${libdir}" -lz
-Cflags: -I"${includedir}"`
+Name: libxml-2.0
+Description: Conan package: libxml-2.0
+Version: 2.11.6
+Libs: -L"${libdir}" -lxml2 -lm -lpthread -ldl
+Cflags: -I"${includedir}" -I"${includedir1}"
+Requires: zlib`
 
 	expectedContent = `prefix={{.Prefix}}
 libdir=${prefix}/lib
 includedir=${prefix}/include
+includedir1=${prefix}/include/libxml2
 bindir=${prefix}/bin
 
-Name: zlib
-Description: Conan package: zlib
-Version: 1.3.1
-Libs: -L"${libdir}" -lz
-Cflags: -I"${includedir}"`
+Name: libxml-2.0
+Description: Conan package: libxml-2.0
+Version: 2.11.6
+Libs: -L"${libdir}" -lxml2 -lm -lpthread -ldl
+Cflags: -I"${includedir}" -I"${includedir1}"`
 )
 
 func TestPCTemplate(t *testing.T) {


### PR DESCRIPTION
Remove `Requires` field in pc file and generate clib's pc only.