### PR TITLE
refactor: support multi internal pc

### DIFF
--- a/cmd/llpkgstore/internal/generate.go
+++ b/cmd/llpkgstore/internal/generate.go
@@ -52,7 +52,7 @@ func runLLCppgGenerateWithDir(dir string) {
 	file.CopyFilePattern(tempDir, dir, "*.pc")
 	// try llcppcfg if llcppg.cfg dones't exist
 	if _, err := os.Stat(filepath.Join(dir, "llcppg.cfg")); os.IsNotExist(err) {
-		cmd := exec.Command("llcppcfg", pcName)
+		cmd := exec.Command("llcppcfg", pcName[0])
 		cmd.Dir = dir
 		pc.SetPath(cmd, tempDir)
 		ret, err := cmd.CombinedOutput()

--- a/internal/pc/tmpl.go
+++ b/internal/pc/tmpl.go
@@ -1,27 +1,54 @@
 package pc
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const PCTemplateSuffix = ".tmpl"
 
 var (
 	// By the way, trim the new line
-	requireMatch = regexp.MustCompile(`\nRequires:\s.*`)
+	requireMatch = regexp.MustCompile(`\nRequires:\s(.*)`)
 	PrefixMatch  = regexp.MustCompile(`^prefix=(.*)`)
 )
 
-func GenerateTemplateFromPC(inputName, outputDir string) error {
+func isInternalDeps(s []string, internalDeps []string) bool {
+	// TODO(ghl): optimize this function, O(m*n) is slow.
+	m := make(map[string]struct{}, len(s))
+
+	for _, str := range s {
+		m[str] = struct{}{}
+	}
+
+	for _, str := range internalDeps {
+		if _, ok := m[str]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func GenerateTemplateFromPC(inputName, outputDir string, internalDeps []string) error {
 	pcContent, err := os.ReadFile(inputName)
 	if err != nil {
 		return err
 	}
 	outputName := filepath.Join(outputDir, filepath.Base(inputName)+PCTemplateSuffix)
 	pcContent = PrefixMatch.ReplaceAll(pcContent, []byte(`prefix={{.Prefix}}`))
-	pcContent = requireMatch.ReplaceAll(pcContent, []byte(""))
+
+	for _, ret := range requireMatch.FindAllSubmatch(pcContent, -1) {
+		// check it's an external deps or not
+		requireName := strings.Fields(string(ret[1]))
+
+		if !isInternalDeps(requireName, internalDeps) {
+			// it's an external deps, can remove.
+			pcContent = bytes.ReplaceAll(pcContent, ret[0], []byte(""))
+		}
+	}
 
 	return os.WriteFile(outputName, pcContent, 0644)
 }

--- a/internal/pc/tmpl_test.go
+++ b/internal/pc/tmpl_test.go
@@ -32,6 +32,43 @@ Version: 2.11.6
 Libs: -L"${libdir}" -lxml2 -lm -lpthread -ldl
 Cflags: -I"${includedir}" -I"${includedir1}"`
 
+	testPCFileCJSON1 = `prefix=/home/vscode/.conan2/p/b/cjson7fb112e50ddea/p
+libdir=${prefix}/lib
+includedir=${prefix}/include
+bindir=${prefix}/bin
+
+Name: cjson
+Description: Conan package: cjson
+Version: 1.7.18
+Libs: -L"${libdir}"
+Cflags: -I"${includedir}"
+Requires: libcjson libcjson_utils`
+
+	testPCFileCJSON2 = `prefix=/home/vscode/.conan2/p/b/cjson7fb112e50ddea/p
+libdir=${prefix}/lib
+includedir=${prefix}/include
+bindir=${prefix}/bin
+
+Name: cjson
+Description: Conan package: cjson
+Version: 1.7.18
+Libs: -L"${libdir}"
+Cflags: -I"${includedir}"
+Requires: libcjson libcjson_utils
+Requires: zlib`
+
+	testPCFileCJSON3 = `prefix=/home/vscode/.conan2/p/b/cjson7fb112e50ddea/p
+libdir=${prefix}/lib
+includedir=${prefix}/include
+bindir=${prefix}/bin
+
+Name: cjson
+Description: Conan package: cjson
+Version: 1.7.18
+Libs: -L"${libdir}"
+Cflags: -I"${includedir}"
+Requires: zlib`
+
 	expectedContent = `prefix={{.Prefix}}
 libdir=${prefix}/lib
 includedir=${prefix}/include
@@ -43,12 +80,35 @@ Description: Conan package: libxml-2.0
 Version: 2.11.6
 Libs: -L"${libdir}" -lxml2 -lm -lpthread -ldl
 Cflags: -I"${includedir}" -I"${includedir1}"`
+
+	expectedContentCJSON = `prefix={{.Prefix}}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+bindir=${prefix}/bin
+
+Name: cjson
+Description: Conan package: cjson
+Version: 1.7.18
+Libs: -L"${libdir}"
+Cflags: -I"${includedir}"
+Requires: libcjson libcjson_utils`
+
+	expectedContentCJSON2 = `prefix={{.Prefix}}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+bindir=${prefix}/bin
+
+Name: cjson
+Description: Conan package: cjson
+Version: 1.7.18
+Libs: -L"${libdir}"
+Cflags: -I"${includedir}"`
 )
 
 func TestPCTemplate(t *testing.T) {
 	os.WriteFile("test.pc", []byte(testPCFile), 0644)
 	os.Mkdir(".generated", 0777)
-	GenerateTemplateFromPC("test.pc", ".generated")
+	GenerateTemplateFromPC("test.pc", ".generated", []string{"libxml-2.0"})
 	defer os.Remove("test.pc")
 	defer os.RemoveAll(".generated")
 	b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
@@ -65,7 +125,7 @@ func TestPCTemplate(t *testing.T) {
 func TestPCTemplateNoRequires(t *testing.T) {
 	os.WriteFile("test.pc", []byte(testPCFile2), 0644)
 	os.Mkdir(".generated", 0777)
-	GenerateTemplateFromPC("test.pc", ".generated")
+	GenerateTemplateFromPC("test.pc", ".generated", []string{"libxml-2.0"})
 	defer os.Remove("test.pc")
 	defer os.RemoveAll(".generated")
 	b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
@@ -79,11 +139,64 @@ func TestPCTemplateNoRequires(t *testing.T) {
 	}
 }
 
+func TestPCTemplateMultiPC(t *testing.T) {
+	deps := []string{"cjson", "libcjson", "libcjson_utils"}
+	t.Run("internal-require", func(t *testing.T) {
+		os.WriteFile("test.pc", []byte(testPCFileCJSON1), 0644)
+		os.Mkdir(".generated", 0777)
+		GenerateTemplateFromPC("test.pc", ".generated", deps)
+		defer os.Remove("test.pc")
+		defer os.RemoveAll(".generated")
+		b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if string(b) != expectedContentCJSON {
+			t.Errorf("unexpected content: got: %s", string(b))
+		}
+	})
+	t.Run("multi-require", func(t *testing.T) {
+		os.WriteFile("test.pc", []byte(testPCFileCJSON2), 0644)
+		os.Mkdir(".generated", 0777)
+		GenerateTemplateFromPC("test.pc", ".generated", deps)
+		defer os.Remove("test.pc")
+		defer os.RemoveAll(".generated")
+		b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if string(b) != expectedContentCJSON {
+			t.Errorf("unexpected content: got: %s", string(b))
+		}
+	})
+
+	t.Run("external-require", func(t *testing.T) {
+		os.WriteFile("test.pc", []byte(testPCFileCJSON3), 0644)
+		os.Mkdir(".generated", 0777)
+		GenerateTemplateFromPC("test.pc", ".generated", deps)
+		defer os.Remove("test.pc")
+		defer os.RemoveAll(".generated")
+		b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if string(b) != expectedContentCJSON2 {
+			t.Errorf("unexpected content: got: %s", string(b))
+		}
+	})
+}
+
 func TestABSPathPCTemplate(t *testing.T) {
 	pcPath, _ := filepath.Abs("test.pc")
 	os.WriteFile(pcPath, []byte(testPCFile), 0644)
 	os.Mkdir(".generated", 0777)
-	GenerateTemplateFromPC(pcPath, ".generated")
+	GenerateTemplateFromPC(pcPath, ".generated", []string{"libxml-2.0"})
 	defer os.Remove(pcPath)
 	defer os.RemoveAll(".generated")
 	b, err := os.ReadFile(filepath.Join(".generated", "test.pc.tmpl"))

--- a/upstream/installer.go
+++ b/upstream/installer.go
@@ -7,8 +7,8 @@ type Installer interface {
 	Config() map[string]string
 	// Install downloads and installs the specified package.
 	// The outputDir is where build artifacts (e.g., .pc files, headers) are stored.
-	// Returns an error if installation fails, pkgConfigName if success.
-	Install(pkg Package, outputDir string) (pkgConfigName string, err error)
+	// Returns an error if installation fails, all the pkgConfigFiles if success.
+	Install(pkg Package, outputDir string) (pkgConfigFiles []string, err error)
 	// Search checks remote repository for the specified package availability.
 	// Returns the search results text and any encountered errors.
 	Search(pkg Package) ([]string, error)

--- a/upstream/installer/conan/output.go
+++ b/upstream/installer/conan/output.go
@@ -5,14 +5,12 @@ type properties struct {
 }
 
 type cppInfo struct {
-	Root struct {
-		Properties properties `json:"properties"`
-	} `json:"root"`
+	Properties properties `json:"properties"`
 }
 
 type packageInfo struct {
-	Name    string  `json:"name"`
-	CppInfo cppInfo `json:"cpp_info"`
+	Name    string             `json:"name"`
+	CppInfo map[string]cppInfo `json:"cpp_info"`
 }
 
 type conanOutput struct {

--- a/upstream/installer/githubreleases/githubreleases.go
+++ b/upstream/installer/githubreleases/githubreleases.go
@@ -49,33 +49,33 @@ func (c *ghReleasesInstaller) Config() map[string]string {
 // Unlike conaninstaller which is used for GitHub Action to obtain binary files
 // this installer is used for `llgo get` to install binary files.
 // The first return value is an empty string, as the pkgConfigName is not necessary for this GitHub Release installer.
-func (c *ghReleasesInstaller) Install(pkg upstream.Package, outputDir string) (string, error) {
+func (c *ghReleasesInstaller) Install(pkg upstream.Package, outputDir string) ([]string, error) {
 	compressPath, err := c.download(c.assertUrl(pkg), outputDir)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if strings.HasSuffix(compressPath, ".tar.gz") {
 		err = c.untargz(outputDir, compressPath)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	} else if strings.HasSuffix(compressPath, ".zip") {
 		err = c.unzip(outputDir, compressPath)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	} else {
-		return "", errors.New("unsupported compressed file format")
+		return nil, errors.New("unsupported compressed file format")
 	}
 	err = os.Remove(compressPath)
 	if err != nil {
-		return "", fmt.Errorf("cannot delete compressed file: %w", err)
+		return nil, fmt.Errorf("cannot delete compressed file: %w", err)
 	}
 	err = c.setPrefix(outputDir)
 	if err != nil {
-		return "", fmt.Errorf("fail to reset .pc prefix: %w", err)
+		return nil, fmt.Errorf("fail to reset .pc prefix: %w", err)
 	}
-	return "", nil
+	return nil, nil
 }
 
 // Warning: not implemented


### PR DESCRIPTION
Some clib like`cjson` has a pc alias to its`libcjson`

In previous version, we don't consider this case.

In this implement, we will pack all internal pc.

Example:
`cjson`: `cjson.pc` `libcjson.pc` `libcjson_utils.pc`
`libxml2`: `libxml-2.0.pc` (exclude `zlib.pc` because of external deps)

Test:
libxml2: https://github.com/MeteorsLiu/llpkg/releases/tag/libxml2%2Fv1.0.0
cjson: https://github.com/MeteorsLiu/llpkg/releases/tag/cjson%2Fv1.0.0

