### PR TITLE
llpkgstore/chore:some short command

### DIFF
--- a/cmd/llpkgstore/internal/generate.go
+++ b/cmd/llpkgstore/internal/generate.go
@@ -16,7 +16,7 @@ import (
 
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "PR Verification",
+	Short: "Generate LLGo bindings",
 	Long:  ``,
 	RunE:  runLLCppgGenerate,
 }

--- a/cmd/llpkgstore/internal/issueclose.go
+++ b/cmd/llpkgstore/internal/issueclose.go
@@ -7,7 +7,7 @@ import (
 
 var issueCloseCmd = &cobra.Command{
 	Use:   "issueclose",
-	Short: "Legacy version maintenance on label creating",
+	Short: "Clean up resources after issue closure",
 	Long:  ``,
 
 	RunE: runIssueCloseCmd,

--- a/cmd/llpkgstore/internal/postprocessing.go
+++ b/cmd/llpkgstore/internal/postprocessing.go
@@ -7,7 +7,7 @@ import (
 
 var postProcessingCmd = &cobra.Command{
 	Use:   "postprocessing",
-	Short: "Verify a PR",
+	Short: "Process merged PR",
 	Long:  ``,
 	RunE:  runPostProcessingCmd,
 }

--- a/cmd/llpkgstore/internal/release.go
+++ b/cmd/llpkgstore/internal/release.go
@@ -7,7 +7,7 @@ import (
 
 var releaseCmd = &cobra.Command{
 	Use:   "release",
-	Short: "Verify a PR",
+	Short: "Build and upload binary packages",
 	Long:  ``,
 	RunE:  runReleaseCmd,
 }


### PR DESCRIPTION
```
llpkgstore/cmd/llpkgstore on  command [?] via 🐹 v1.23.4 
❯ llpkgstore --help
This application is a tool that integrates llpkg-related functionality,
such as binary installation, configuration file parsing, etc.

Usage:
  llpkgstore [command]

Available Commands:
  completion     Generate the autocompletion script for the specified shell
  demotest       A tool that runs all demo
  generate       Generate LLGo bindings
  help           Help about any command
  install        Manually install a package
  issueclose     Clean up resources after issue closure
  labelcreate    Legacy version maintenance on label creating
  postprocessing Process merged PR
  release        Build and upload binary packages
  verification   PR Verification

Flags:
  -h, --help     help for llpkgstore
  -t, --toggle   Help message for toggle

Use "llpkgstore [command] --help" for more information about a command.
```